### PR TITLE
Corrects Svelte component watch/reload

### DIFF
--- a/.changes/unreleased/fixed-20250401-002320.yaml
+++ b/.changes/unreleased/fixed-20250401-002320.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Reduce Vite's watcher exclusion to detect 'lib' changes
+time: 2025-04-01T00:23:20.760299+02:00
+custom:
+    Issue: ""

--- a/vite-plugin-crystal/src/crystal.js
+++ b/vite-plugin-crystal/src/crystal.js
@@ -82,7 +82,7 @@ export default function crystal(options = {}) {
           },
           watch: {
             // Exclude shard symlinks
-            ignored: ["**/lib/**"],
+            ignored: ["./lib/**"],
           },
         },
       };


### PR DESCRIPTION
When using Vite development server, Svelte's preference for `lib` directory was incorrectly ignored, causing anything with `/lib/` in the path to be excluded.

This was in place due Shards usage of `lib` to install dependencies and the endless nested symlinks.

Adjusted the ignore rules to exclude things only relative to the root of the server.