### PR TITLE
Fixes Vite's server watch catching shards symlinks

### DIFF
--- a/.changes/unreleased/fixed-20250412-175646.yaml
+++ b/.changes/unreleased/fixed-20250412-175646.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Fix Vite watch catching deep nested symlinks from shards
+time: 2025-04-12T17:56:46.374667+02:00
+custom:
+    Issue: ""

--- a/vite-plugin-crystal/src/crystal.js
+++ b/vite-plugin-crystal/src/crystal.js
@@ -81,8 +81,8 @@ export default function crystal(options = {}) {
             clientPort: appPort,
           },
           watch: {
-            // Exclude shard symlinks
-            ignored: ["./lib/**"],
+            // Exclude shards and nested symlinks
+            ignored: [`${projectRoot}/lib/**`],
           },
         },
       };


### PR DESCRIPTION
`./lib` pattern was not correctly processed by Chokidar (the library used by Vite's server watcher). This caused that under certian scenarios, the `lib` symlinks were seen and made Vite to throw an error.