### PR TITLE
Fixes loading manifest with bundled webfonts

### DIFF
--- a/.changes/unreleased/fixed-20250427-115255.yaml
+++ b/.changes/unreleased/fixed-20250427-115255.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Properly load manifest that contains Webfonts
+time: 2025-04-27T11:52:55.306845+02:00
+custom:
+    Issue: ""

--- a/spec/fixtures/manifest.json
+++ b/spec/fixtures/manifest.json
@@ -1,4 +1,12 @@
 {
+  "node_modules/inter-ui/variable/InterVariable-Italic.woff2": {
+    "file": "assets/InterVariable-Italic-FCBEiFp6.woff2",
+    "src": "node_modules/inter-ui/variable/InterVariable-Italic.woff2"
+  },
+  "node_modules/inter-ui/variable/InterVariable.woff2": {
+    "file": "assets/InterVariable-DiVDrmQJ.woff2",
+    "src": "node_modules/inter-ui/variable/InterVariable.woff2"
+  },
   "src/frontend/main.js": {
     "file": "assets/main-123abc.js",
     "name": "main",

--- a/src/vite.cr
+++ b/src/vite.cr
@@ -23,9 +23,6 @@ class Vite
     property name : String?
     property src : String
 
-    @[JSON::Field(key: "isEntry")]
-    property? entry : Bool
-
     property css : Array(String)?
   end
 


### PR DESCRIPTION
Certain webfonts can be imported via CSS, but those will not define a `isEntry` field.

This field was unused and not covered in the Vite's backend integration documentation, so removed.

Ref:
https://vite.dev/guide/backend-integration