### PR TITLE
Corrects assets URL when running `vite build`

### DIFF
--- a/.changes/unreleased/fixed-20250427-124503.yaml
+++ b/.changes/unreleased/fixed-20250427-124503.yaml
@@ -1,0 +1,5 @@
+kind: fixed
+body: Asset URLs correctly point to /build/ instead of /vite-dev/
+time: 2025-04-27T12:45:03.288482+02:00
+custom:
+    Issue: "7"

--- a/vite-plugin-crystal/src/crystal.js
+++ b/vite-plugin-crystal/src/crystal.js
@@ -58,9 +58,12 @@ export default function crystal(options = {}) {
   };
   return {
     name: "crystal",
-    config() {
+    config(config, { command }) {
+      // Check if we're in dev (serve) or build mode
+      const isDev = command === "serve";
+
       return {
-        base: "/vite-dev/",
+        base: isDev ? "/vite-dev/" : "/build/",
         publicDir: false,
         resolve: {
           alias: {


### PR DESCRIPTION
Only prefix asset URLs with /vite-dev/ during development (vite dev mode).

Fixes #7